### PR TITLE
Remove 'to top' links

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -75,10 +75,6 @@ activate :directory_indexes
 
 # Methods defined in the helpers block are available in templates
 helpers do
-  def link_to_top
-    link_to 'to the top ^', '#', class: 'back_top'
-  end
-
   def link_to_section(section, link)
     if current_page.url == '/'
       link_to section, link

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -54,9 +54,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
   </div>
 
   <div class="section" id="about">
-    <h3 class="centered">About
-      <%= link_to_top %>
-    </h3>
+    <h3 class="centered">About</h3>
     <p class="intro">
       <span>EuRuKo (the European Ruby Conference) is an annual conference which focuses on the Ruby programming language, with an informal atmosphere and lots of opportunities to listen, to talk, to hack, to have fun and where delegates experience distinct and insightful content from speakers of the highest calibre.</span>
       <span>EuRuKo is being organised for the past 10 years in cities around Europe by Ruby developers for Ruby developers. It’s a truly volunteer-based event and like Ruby it is fostered by the community. Each year a different european city and its local community of Ruby enthusiasts are tasked to host the event and that’s what makes EuRuKo one of a kind.</span>
@@ -66,9 +64,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
   </div>
 
   <div class="section" id="speakers">
-    <h3 class="centered">Speakers
-      <%= link_to_top %>
-    </h3>
+    <h3 class="centered">Speakers</h3>
     <p class="intro">
       <span>We consider the most important aspects of EuRuKo to be the delegates engagement and the conference programme, so we are working hard to announce an excellent programme, as well as a really exciting way of selecting speakers and topics.</span>
       <%= link_to 'Submit your proposal now! ›', 'http://cfp.euruko2013.org', class: 'more' %>
@@ -84,9 +80,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
   </div>
 
   <div class="section" id="tickets">
-    <h3 class="centered">Tickets
-      <%= link_to_top %>
-    </h3>
+    <h3 class="centered">Tickets</h3>
     <div class="centered">
       <div class="ticket"></div>
       <p>
@@ -98,9 +92,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
 
   <div class="section" id="venue">
     <div class="centered" itemscope itemprop="location" itemtype="http://schema.org/Place">
-      <h3>Venue
-        <%= link_to_top %>
-      </h3>
+      <h3>Venue</h3>
 
       <h4 itemprop="address">
         <span itemprop="name">Badminton Theater</span>, Olympic Properties Goudi<br/>
@@ -116,9 +108,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
   </div>
 
   <div class="section" id="sponsors">
-    <h3 class="centered">Sponsors
-      <%= link_to_top %>
-    </h3>
+    <h3 class="centered">Sponsors</h3>
     <p class="centered">
       Boldly show your Ruby love - be a sponsor
       <%= link_to 'download sponsorships brochure', 'sponsors/euruko2013-sponsorship-packages.pdf', class: 'external-link brochure' %>
@@ -126,9 +116,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
   </div>
 
   <div class="section" id="contributors">
-    <h3 class="centered">Contributors
-      <%= link_to_top %>
-    </h3>
+    <h3 class="centered">Contributors</h3>
     <h4>Organisers</h4>
     <ul class="centered committee">
       <li>
@@ -178,9 +166,7 @@ description: EuRuKo 2013 - The European Ruby Conference in sunny Athens, Greece 
   </div>
 
   <div class="section" id="contact">
-    <h3 class="centered">Contact
-      <%= link_to_top %>
-    </h3>
+    <h3 class="centered">Contact</h3>
     <p class="centered">
       <span>Stay tuned and don’t miss out on news about EuRuKo 2013. Remember that traditionally EuRuKo tickets go in seconds so follow our progress closely and be prepared. We are sure you'll love this year’s EuRuKo.</span>
     </p>


### PR DESCRIPTION
These are no longer needed with the sticky navbar.
