### PR TITLE
Adds standalone page for speakers' list

### DIFF
--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -2,14 +2,17 @@ speakers:
   - matz:
     name: 'Yukihiro "Matz" Matsumoto'
     short_name: 'matz'
+    title: 'Ruby chief architect'
     short_bio: "Yukihiro “Matz” Matsumoto is the mastermind behind the inception of Ruby. Since 1993 he has been designing our precious jewel up to its latest 2.0 version. Meanwhile he has been working on mruby, a lightweight Ruby implementation. This summer, he will be celebrating with us the 20th anniversary of Ruby."
 
   - koichi:
     name: 'Koichi Sasada'
     short_name: 'koichi'
+    title: 'Ruby core commiter (CRuby VM, YARV)'
     short_bio: 'Koichi knows the inside outs of the Ruby VM. He has developed YARV (Yet another Ruby VM) which became the official Ruby VM when Ruby 1.9 was released. We believe he will give lots of insights in the Ruby VM, the new performance improments in Ruby 2.0 and will hint at the future of the Ruby VM.'
 
   - klabnik:
     name: 'Steve Klabnik'
     short_name: 'klabnik'
+    title: 'Instructor and Open Source lead'
     short_bio: 'Steve enjoys turning coffee into code, writing, philosophy, and physical activity. He is a contributor to many high visibility open source projects such as Sinatra, Resque, Rubinius and of course the venerable Ruby on Rails web framework. His talks are always insightful and inspiring. We should not expect anything less for EuRuKo.'

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -1,0 +1,15 @@
+speakers:
+  - matz:
+    name: 'Yukihiro "Matz" Matsumoto'
+    short_name: 'matz'
+    short_bio: "Yukihiro “Matz” Matsumoto is the mastermind behind the inception of Ruby. Since 1993 he has been designing our precious jewel up to its latest 2.0 version. Meanwhile he has been working on mruby, a lightweight Ruby implementation. This summer, he will be celebrating with us the 20th anniversary of Ruby."
+
+  - koichi:
+    name: 'Koichi Sasada'
+    short_name: 'koichi'
+    short_bio: 'Koichi knows the inside outs of the Ruby VM. He has developed YARV (Yet another Ruby VM) which became the official Ruby VM when Ruby 1.9 was released. We believe he will give lots of insights in the Ruby VM, the new performance improments in Ruby 2.0 and will hint at the future of the Ruby VM.'
+
+  - klabnik:
+    name: 'Steve Klabnik'
+    short_name: 'klabnik'
+    short_bio: 'Steve enjoys turning coffee into code, writing, philosophy, and physical activity. He is a contributor to many high visibility open source projects such as Sinatra, Resque, Rubinius and of course the venerable Ruby on Rails web framework. His talks are always insightful and inspiring. We should not expect anything less for EuRuKo.'

--- a/source/speakers.html.erb
+++ b/source/speakers.html.erb
@@ -4,11 +4,7 @@ title: EuRuKo 2013 - Athens | Speakers
 <section id="speakers">
   <ul class="centered" itemprop="performer" itemtype="http://schema.org/Person">
     <% data.speakers.speakers.each_with_index do |speaker, i| %>
-      <% if (i+1) % 2 == 0 %>
-        <li class="left" id="<%= speaker.short_name %>">
-      <% else %>
-        <li class="right" id="<%= speaker.short_name %>">
-      <% end %>
+        <li class="<%= i.even? ? "left" : "right" %>" id="<%= speaker.short_name %>">
           <h4><span class="name" itemprop="name"><%= speaker.name %></span></h4>
           <h5><%= speaker.name %><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
         <p><%= speaker.short_bio %></p>

--- a/source/speakers.html.erb
+++ b/source/speakers.html.erb
@@ -1,11 +1,18 @@
-<ul class="speakers">
-  <% data.speakers.speakers.each_with_index do |speaker, i| %>
-    <% if i > 0 %>
-      <p class="separator"><%= '&amp;' if i > 0 %></p>
+---
+title: EuRuKo 2013 - Athens | Speakers
+---
+<section id="speakers">
+  <ul class="centered" itemprop="performer" itemtype="http://schema.org/Person">
+    <% data.speakers.speakers.each_with_index do |speaker, i| %>
+      <% if (i+1) % 2 == 0 %>
+        <li class="left" id="<%= speaker.short_name %>">
+      <% else %>
+        <li class="right" id="<%= speaker.short_name %>">
+      <% end %>
+          <h4><span class="name" itemprop="name"><%= speaker.name %></span></h4>
+          <h5><%= speaker.name %><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
+        <p><%= speaker.short_bio %></p>
+        </li>
     <% end %>
-    <li class="speaker">
-      <%= image_tag "speakers/#{speaker}.png", alt: speaker, itemprop: "image", class: "left" %>
-      <p><%= speaker.short_bio %></p>
-    </li>
-  <% end %>
-</ul>
+  </ul>
+</section>

--- a/source/speakers.html.erb
+++ b/source/speakers.html.erb
@@ -1,0 +1,11 @@
+<ul class="speakers">
+  <% data.speakers.speakers.each_with_index do |speaker, i| %>
+    <% if i > 0 %>
+      <p class="separator"><%= '&amp;' if i > 0 %></p>
+    <% end %>
+    <li class="speaker">
+      <%= image_tag "speakers/#{speaker}.png", alt: speaker, itemprop: "image", class: "left" %>
+      <p><%= speaker.short_bio %></p>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
The page looks like this
![Screen Shot 2013-04-12 at 11 15 08 PM](https://f.cloud.github.com/assets/1211471/374951/be78c3de-a3ad-11e2-954b-d0f870983573.png)

It's all dynamically generated.

New speakers can be added at data/speakers.yml
