### PR TITLE
Adds individual speaker pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -66,6 +66,14 @@ end
 page "/blog/feed.xml", :layout => false
 
 ###
+# Spakers
+###
+
+data.speakers.speakers.each do |speaker|
+  proxy "/speakers/#{speaker.short_name}.html", "/speakers/speaker.html", locals: { speaker: speaker }, ignore: true
+end
+
+###
 # Helpers
 ###
 

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -4,15 +4,18 @@ speakers:
     short_name: 'matz'
     title: 'Ruby chief architect'
     short_bio: "Yukihiro “Matz” Matsumoto is the mastermind behind the inception of Ruby. Since 1993 he has been designing our precious jewel up to its latest 2.0 version. Meanwhile he has been working on mruby, a lightweight Ruby implementation. This summer, he will be celebrating with us the 20th anniversary of Ruby."
+    bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ut nisi in risus scelerisque ornare id eu quam. Quisque nec mattis purus. Morbi lectus eros, dapibus a lacinia iaculis, mollis eu leo. Integer commodo sagittis tellus nec porttitor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In scelerisque odio et purus posuere auctor. Mauris sed mi sed libero scelerisque scelerisque a quis libero. Nunc justo elit, molestie at aliquam nec, dapibus ac dui. Integer dictum vehicula cursus. Vestibulum vitae purus at ligula semper ornare. Nunc lacinia ligula id sapien luctus porta. Praesent odio metus, bibendum ac ultricies et, mattis in urna. Nunc eleifend sapien non magna sodales consequat. Suspendisse a lorem a erat pretium consectetur id id erat."
 
   - koichi:
     name: 'Koichi Sasada'
     short_name: 'koichi'
     title: 'Ruby core commiter (CRuby VM, YARV)'
     short_bio: 'Koichi knows the inside outs of the Ruby VM. He has developed YARV (Yet another Ruby VM) which became the official Ruby VM when Ruby 1.9 was released. We believe he will give lots of insights in the Ruby VM, the new performance improments in Ruby 2.0 and will hint at the future of the Ruby VM.'
+    bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ut nisi in risus scelerisque ornare id eu quam. Quisque nec mattis purus. Morbi lectus eros, dapibus a lacinia iaculis, mollis eu leo. Integer commodo sagittis tellus nec porttitor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In scelerisque odio et purus posuere auctor. Mauris sed mi sed libero scelerisque scelerisque a quis libero. Nunc justo elit, molestie at aliquam nec, dapibus ac dui. Integer dictum vehicula cursus. Vestibulum vitae purus at ligula semper ornare. Nunc lacinia ligula id sapien luctus porta. Praesent odio metus, bibendum ac ultricies et, mattis in urna. Nunc eleifend sapien non magna sodales consequat. Suspendisse a lorem a erat pretium consectetur id id erat."
 
   - klabnik:
     name: 'Steve Klabnik'
     short_name: 'klabnik'
     title: 'Instructor and Open Source lead'
     short_bio: 'Steve enjoys turning coffee into code, writing, philosophy, and physical activity. He is a contributor to many high visibility open source projects such as Sinatra, Resque, Rubinius and of course the venerable Ruby on Rails web framework. His talks are always insightful and inspiring. We should not expect anything less for EuRuKo.'
+    bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ut nisi in risus scelerisque ornare id eu quam. Quisque nec mattis purus. Morbi lectus eros, dapibus a lacinia iaculis, mollis eu leo. Integer commodo sagittis tellus nec porttitor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In scelerisque odio et purus posuere auctor. Mauris sed mi sed libero scelerisque scelerisque a quis libero. Nunc justo elit, molestie at aliquam nec, dapibus ac dui. Integer dictum vehicula cursus. Vestibulum vitae purus at ligula semper ornare. Nunc lacinia ligula id sapien luctus porta. Praesent odio metus, bibendum ac ultricies et, mattis in urna. Nunc eleifend sapien non magna sodales consequat. Suspendisse a lorem a erat pretium consectetur id id erat."

--- a/source/speakers.html.erb
+++ b/source/speakers.html.erb
@@ -6,7 +6,7 @@ title: EuRuKo 2013 - Athens | Speakers
     <% data.speakers.speakers.each_with_index do |speaker, i| %>
         <li class="<%= i.even? ? "left" : "right" %>" id="<%= speaker.short_name %>">
           <h4><span class="name" itemprop="name"><%= speaker.name %></span></h4>
-          <h5><%= speaker.name %><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
+          <h5><a href="/speakers/<%= speaker.short_name %>"><%= speaker.name %></a><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
         <p><%= speaker.short_bio %></p>
         </li>
     <% end %>

--- a/source/speakers/speaker.html.erb
+++ b/source/speakers/speaker.html.erb
@@ -1,0 +1,7 @@
+---
+title: EuRuKo 2013 - Athens | Speakers
+---
+
+<h4><span class="name" itemprop="name"><%= speaker.name %></span></h4>
+<h5><%= speaker.name %><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
+<p><%= speaker.short_bio %></p>

--- a/source/speakers/speaker.html.erb
+++ b/source/speakers/speaker.html.erb
@@ -1,7 +1,12 @@
 ---
 title: EuRuKo 2013 - Athens | Speakers
 ---
-
-<h4><span class="name" itemprop="name"><%= speaker.name %></span></h4>
-<h5><%= speaker.name %><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
-<p><%= speaker.short_bio %></p>
+<section id="speakers">
+  <ul class="centered" itemprop="performer" itemtype="http://schema.org/Person">
+        <li class="left" id="<%= speaker.short_name %>">
+          <h4><span class="name" itemprop="name"><%= speaker.name %></span></h4>
+          <h5><%= speaker.name %><span class="subtitle" itemprop="jobTitle"><%= speaker.title %></span></h5>
+        <p><%= speaker.bio %></p>
+        </li>
+  </ul>
+</section>


### PR DESCRIPTION
This pull request refers to #31 

The things I did.
- Added /speakers directory
- Added /speakers/speaker.html.erb template for individual pages

Adds individual pages for every speaker dynamically according to data/speakers.yml under the /speakers/<%= speaker.short_name %> url and  **lorem ipsum** bio data.

Also adds a link to those individual pages in the /speakers for every speaker.

Still needs real data for bio though

@fotos Any ideas?
