### PR TITLE
Update travel-information.html.erb - Links missing

### DIFF
--- a/source/guide/travel-information.html.erb
+++ b/source/guide/travel-information.html.erb
@@ -86,8 +86,8 @@ menu_item: travel-information
                     Take Metro Line 3 (Egaleo – Douk. Plakentias – Airport), which connects the Athens airport with the city center.
                     Trains run every 30 minutes, 7 days a week from 6:30 a.m. to 11:30 p.m.
                     The trip from/to the Airport to Syntagma station (Athens center) lasts 40 minutes.
-                    See the Metro timetable to the airport here and also an Athens airport railway station map.
-                    For ticket info see Athens Transport tickets and cards.
+                    See the Metro timetable to the airport <a href="http://www.stasy.gr/index.php?id=70&L=1">here</a>.
+                    For ticket info see <a href="http://www.athenstransport.com/english/tickets/">Athens Transport tickets and cards</a>.
                 </p>
 
                 <h4>24-hour express buses</h4>


### PR DESCRIPTION
The metro section contained the text found [here](http://www.athenstransport.com/english/) without the links. I added the first and last and deleted the other as it leads to a 404 even on the original site.
